### PR TITLE
Add support for deeplink redirect on Android

### DIFF
--- a/src/assets/js/verify.js
+++ b/src/assets/js/verify.js
@@ -1,5 +1,6 @@
 var iOS = !!navigator.platform && /iPad|iPhone|iPod/.test(navigator.platform);
+var Android = !!navigator.platform && /Android|Linux|Linux armv6l|Linux armv7l/.test(navigator.platform);
 
-if (iOS) {
-  window.location = __didcomm_url;
+if (iOS || Android) {
+  window.location = __streetcred_url;
 }


### PR DESCRIPTION
Addresses #44 

Tested locally it works: the app that was registered to handle the `didcomm` deeplinck is opened correctly.

Android seems to however have *some* cases where the check may not work: in that scenario the QR Code screen will remain visible. See [here](https://stackoverflow.com/questions/19877924/what-is-the-list-of-possible-values-for-navigator-platform-as-of-today) for additional info.