### PR TITLE
Upgrade ACA-Py to 0.6.0

### DIFF
--- a/docker/iiw-book-agent/Dockerfile
+++ b/docker/iiw-book-agent/Dockerfile
@@ -1,3 +1,3 @@
-FROM bcgovimages/aries-cloudagent:py36-1.15-0_0.5.6
+FROM bcgovimages/aries-cloudagent:py36-1.15-1_0.6.0
 
 RUN echo "Just pulling the image from Docker Hub"

--- a/jenkins/iiwbook/Jenkinsfile
+++ b/jenkins/iiwbook/Jenkinsfile
@@ -15,11 +15,11 @@ def COMPONENTS = ['iiw-book-agent', 'iiw-book-service']
 def TAG_NAMES = ['dev', 'test', 'prod']
 
 // Edit your deployment environment names below
-def DEP_ENV_NAMES = ['tools', 'dev', 'test', 'prod']
+def DEP_ENV_NAMES = ['dev', 'test', 'prod']
 
 
 // The base namespace of you environments.
-def NAME_SPACE = 'devex-von-image'
+def NAME_SPACE = 'a99fd4'
 
 // Get an image's hash tag
 String getImageTagHash(String imageName, String tag = "") {

--- a/openshift/templates/iiw-book-agent/iiw-book-agent-build.param
+++ b/openshift/templates/iiw-book-agent/iiw-book-agent-build.param
@@ -4,12 +4,11 @@
 # Template File: ../openshift/templates/iiw-book-agent/iiw-book-agent-build.yaml
 #=========================================================
 NAME=iiw-book-agent
-# APP_NAME=iiw-book
-# CRED_NAME=artifactory-creds
-# DOCKER_REG=docker-remote.artifacts.developer.gov.bc.ca/bcgovimages/aries-cloudagent:py36-1.15-0_0.5.6
+APP_NAME=iiw-book
 GIT_REPO_URL=https://github.com/bcgov/iiwbook.git
 GIT_REF=master
-# SOURCE_CONTEXT_DIR=
-# DOCKER_FILE_PATH=./docker/iiw-book-agent/Dockerfile
-# NO_CACHE=true
-# OUTPUT_IMAGE_TAG=latest
+SOURCE_CONTEXT_DIR=
+DOCKER_FILE_PATH=./docker/iiw-book-agent/Dockerfile
+SOURCE_IMAGE=docker-remote.artifacts.developer.gov.bc.ca/bcgovimages/aries-cloudagent:py36-1.15-1_0.6.0
+NO_CACHE=true
+OUTPUT_IMAGE_TAG=latest

--- a/openshift/templates/iiw-book-agent/iiw-book-agent-build.yaml
+++ b/openshift/templates/iiw-book-agent/iiw-book-agent-build.yaml
@@ -30,11 +30,9 @@ objects:
       strategy:
         type: Docker
         dockerStrategy:
-          pullSecret:
-            name: ${CRED_NAME}
           from:
             kind: DockerImage
-            name: ${DOCKER_REG}
+            name: ${SOURCE_IMAGE}
           dockerfilePath: ${DOCKER_FILE_PATH}
       output:
         to:
@@ -46,16 +44,6 @@ parameters:
     description: The name assigned to all of the resources defined in this template.
     required: true
     value: iiw-book-agent
-  - name: CRED_NAME
-    displayName: Crednetial Name
-    description: The name of the credential used for pull secrets.
-    required: true
-    value: artifactory-creds
-  - name: DOCKER_REG
-    displayName: Docker-Registry
-    description: The name of the docker server
-    required: false
-    value: docker-remote.artifacts.developer.gov.bc.ca/bcgovimages/aries-cloudagent:py36-1.15-0_0.5.6
   - name: APP_NAME
     displayName: App Name
     description: Used to group components together.
@@ -81,6 +69,11 @@ parameters:
     description: The path to the docker file defining the build.
     required: false
     value: ./docker/iiw-book-agent/Dockerfile
+  - name: SOURCE_IMAGE
+    displayName: Source Image
+    description: The fully-qualified name of the source image for this component. 
+    required: true
+    value: docker-remote.artifacts.developer.gov.bc.ca/bcgovimages/aries-cloudagent:py36-1.15-1_0.6.0
   - name: NO_CACHE
     displayName: No Cache
     description: Controls the docker build noCache setting.

--- a/openshift/templates/iiw-book-agent/iiw-book-agent-deploy.yaml
+++ b/openshift/templates/iiw-book-agent/iiw-book-agent-deploy.yaml
@@ -198,6 +198,7 @@ objects:
                   --wallet-type indy
                   --auto-accept-invites
                   --auto-accept-requests
+                  --auto-provision
                   $([ ! -z "${AGENT_ADMIN_API_KEY}" ] && echo "--admin-api-key ${AGENT_ADMIN_API_KEY}" || echo "--admin-insecure-mode")
                   );
               env:


### PR DESCRIPTION
Changes to the pipeline are not used.

Build configurations have been updated to match the latest patter, which does not include an explicit `pullSecret`.